### PR TITLE
(FFM-7026) Convert to drone plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN \
 
 FROM ubuntu:20.04
 COPY --from=builder /piranha/target/release/polyglot_piranha /usr/bin
+COPY flag_cleanup.sh /bin/
 
-# install git
-RUN \
-    apt-get install -y git \
+ENTRYPOINT ["/bin/bash", "/bin/flag_cleanup.sh"]

--- a/flag_cleanup.sh
+++ b/flag_cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ -z ${PLUGIN_ARGS} ]]; then
+  echo "missing required parameter args"
+  exit 1
+fi
+
+polyglot_piranha $PLUGIN_ARGS


### PR DESCRIPTION
Convert image to be a drone plugin that runs the piranha binary by default